### PR TITLE
getData: field cleanup fix for selects

### DIFF
--- a/endless_pagination/static/endless_pagination/js/endless-pagination.js
+++ b/endless_pagination/static/endless_pagination/js/endless-pagination.js
@@ -254,7 +254,6 @@
                     function(i, v) 
                     {
                         if ( formValues.indexOf(v.name) > -1 ) {
-
                             if ( data[v.name].constructor != Array )
                                 data[v.name] = [data[v.name]];
 
@@ -266,13 +265,15 @@
                     }
                 );
 
+                // compare form fields value with URL parameters
                 $('select', $( settings.formSelector )).each(
-                      function()
-                      {
-                         var selectName = $(this).attr('name');
-                         if ( !$(this).val() && data[selectName] != undefined )
-                            delete data[selectName];
-                      }
+                    function()
+                    {
+                        var selectName = $(this).attr('name');
+                        // check field value length (since we have strings and arrays)
+                        if ( $(this).val().length === 0 && data[selectName] !== undefined )
+                           delete data[selectName];
+                    }
                 );
             }
 


### PR DESCRIPTION
When comparing which GET parameters to keep based on the form that is supposedly submitted (no, I can't understand why we don't simply reassemble a new URL from the form's content...) select fields that contains a [] didn't get removed because an empty list isn't false in Javascript