### PR TITLE
Use traditional $.param to ensure QueryDict key won't change

### DIFF
--- a/endless_pagination/static/endless_pagination/js/endless-pagination.js
+++ b/endless_pagination/static/endless_pagination/js/endless-pagination.js
@@ -186,6 +186,7 @@
                     url:  url,
                     dataType: 'html',
                     method: 'GET',
+                    traditional: true,  // avoids having list keys converted with keyname%5B%5D
                     data: param.data,
                     beforeSend: function()
                     {
@@ -305,7 +306,7 @@
                         var data = methods.getData();
                         delete data['page'];
 
-                        var urlSearch = settings.endPoint + '?' + $.param( data );
+                        var urlSearch = settings.endPoint + '?' + $.param( data, true ); // use `traditional`
                         window.history.pushState( {}, "Endless Pagination", urlSearch );
 
                         var params = {


### PR DESCRIPTION
In current jQuery 3.x not using "traditional" means that a single value from a select2 field will become for example `facility=345` while 2 values become a list rendered as `facility%5B%5D=345&facility%5B%5D=231` and it'll require to check for 2 different keys in the request.GET QueryDict().
To get the old behavior we need to set `traditional: true` in $.ajax() calls or `true` as second parameter of $.param()